### PR TITLE
Add milestones so that chain id can be used

### DIFF
--- a/docker_interop/app/src/main/resources/besu_genesis_template.json
+++ b/docker_interop/app/src/main/resources/besu_genesis_template.json
@@ -1,7 +1,11 @@
 {
 	"config": {
-		"chainId": 2017,
+		"chainid": 2017,
 		"homesteadBlock": 0,
+		"eip150Block": 0,
+		"eip155Block": 0,
+		"eip158Block": 0,
+		"byzantiumBlock": 0,
 		"qbft": {
 			"epochlength": 30000,
 			"blockperiodseconds": %BLOCK_PERIOD%,

--- a/docker_interop/app/src/main/resources/quorum_genesis_template.json
+++ b/docker_interop/app/src/main/resources/quorum_genesis_template.json
@@ -2,6 +2,10 @@
   "config": {
     "chainId": 2017,
     "homesteadBlock": 0,
+    "eip150Block": 0,
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
     "istanbul": {
       "epoch": 30000,
       "policy": 0,


### PR DESCRIPTION
Some fixes so we can use chain id in our testing.

* Add additional milestones so that chain id can be used. Chain id was only added in eip158 so need to at least enable that otherwise we can't use a chain id and EthSigner only works with a chainid.
* Fix config for Besu. Config key must be "chainid" not "chainId"